### PR TITLE
Firmware: use proper hostname

### DIFF
--- a/doc/QuickStart.md
+++ b/doc/QuickStart.md
@@ -42,7 +42,7 @@ esptool.py --chip esp8266 --port <PORT> --baud 115200 --before default_reset --a
 
 ### Connect the device to your Wi-Fi network
 
-An unconfigured device always boot up acting as a Wi-Fi access point with a name like `ESP_abcdef`.
+An unconfigured device always boot up acting as a Wi-Fi access point with a name like `CheckMeet_ABCDEF`.
 
 1. Connect to the device via Wi-Fi, a cellphone can be used for this.
 2. The device will present a captive portal where the Wi-Fi can be configured.

--- a/firmware/firmware.ino
+++ b/firmware/firmware.ino
@@ -71,7 +71,7 @@ void setup() {
   firmware = make_unique<Firmware>(*device);
 
   WiFi.mode(WIFI_STA);
-  if (WiFiManager().autoConnect()) {
+  if (WiFiManager().autoConnect(fmt("CheckMeet_%06X", ESP.getChipId()).c_str())) {
     Serial.println("Connected \\o/");
   } else {
     Serial.println("Failed to connect :(");

--- a/firmware/firmware.ino
+++ b/firmware/firmware.ino
@@ -7,6 +7,7 @@
 #include <TM1637Display.h>
 
 #include "lib_firmware.h"
+#include "serialnames.h"
 
 class Device : public I_Device {
   static constexpr int NUM_LEDS = 6;
@@ -70,7 +71,9 @@ void setup() {
   device = make_unique<Device>();
   firmware = make_unique<Firmware>(*device);
 
+  const auto hostname = computeNameForId(ESP.getChipId());
   WiFi.mode(WIFI_STA);
+  WiFi.hostname(hostname.c_str());
   if (WiFiManager().autoConnect(fmt("CheckMeet_%06X", ESP.getChipId()).c_str())) {
     Serial.println("Connected \\o/");
   } else {

--- a/firmware/firmware.ino
+++ b/firmware/firmware.ino
@@ -4,6 +4,7 @@
 #define FASTLED_ESP8266_RAW_PIN_ORDER
 #include <FastLED.h>
 
+#include <ESP8266mDNS.h>
 #include <TM1637Display.h>
 
 #include "lib_firmware.h"
@@ -82,12 +83,17 @@ void setup() {
   Udp.begin(localUdpPort);
   Serial.printf("Now listening at IP %s, UDP port %d\n", WiFi.localIP().toString().c_str(), localUdpPort);
   pinMode(PIN_BUTTON, INPUT_PULLUP);
+  if (MDNS.begin(hostname.c_str())) {
+    MDNS.addService("checkmeet", "udp", localUdpPort);
+  }
 }
 
 void loop() {
   Timestamp now = millis();
 
   firmware->loopStarted(now);
+
+  MDNS.update();
 
   int packetSize = Udp.parsePacket();
   if (packetSize) {


### PR DESCRIPTION
This PR organizes the hostname usage on the device.

- [x] Use `CheckMeet_ABCDEF` instead of `ESP_ABCDEF` while configuring WiFi
- [x] Use animal names as hostnames
- [x] Advertise hostname via mDNS
- [x] Advertise UDP service `checkmeet` via mDNS

This PR fixes one half of #20, the other half should be taken care of in the service. Here is an example python code on how to discover a CheckMeet device:

```python
#!/usr/bin/env python3
from zeroconf import Zeroconf

class Listener:

    def add_service(self, zeroconf, serviceType, name):

        info = zeroconf.get_service_info(serviceType, name)

        print("Address: " + str(info.parsed_addresses()))
        print("Port: " + str(info.port))
        print("Service Name: " + info.name)
        print("Server: " + info.server)
        print("Properties: " + str(info.properties))


zconf = Zeroconf()

serviceListener = Listener()

zconf.add_service_listener("_checkmeet._udp.local.", serviceListener)

input("Press enter to close... \n")
zconf.close()
```